### PR TITLE
Fix the Ubuntu build on s390x

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,14 +1,16 @@
 FROM    ubuntu:22.04
 
-ARG     RUNNERREPO="https://github.com/actions/runner" RUNNERPATCH SDK ARCH
-
 ENV     DEBIAN_FRONTEND=noninteractive
 
 RUN     apt-get -qq update -y && \
         apt-get -qq -y install wget git sudo alien curl libicu70 sudo && \
         apt autoclean
 
+RUN     sed -i'' -e 's/--no-absolute-filenames//' /usr/share/perl5/Alien/Package/Rpm.pm
+
 COPY    build-files/convert-rpm.sh /tmp
+
+ARG     RUNNERREPO="https://github.com/actions/runner" RUNNERPATCH SDK ARCH
 
 RUN     /tmp/convert-rpm.sh ${SDK}
 
@@ -22,15 +24,17 @@ RUN     cd /tmp && \
         git clone -q ${RUNNERREPO} && \
         cd runner && \
         git checkout $(git describe --tags $(git rev-list --tags --max-count=1)) -b build && \
-        git apply /tmp/runner.patch 
+        git apply /tmp/runner.patch
 
 RUN     if [ "${SDK}" -ne 6 ]; then \
             cd /usr/lib64/dotnet/packs; \
-            ln -s Microsoft.AspNetCore.App.Ref Microsoft.AspNetCore.App.Runtime.linux-${ARCH}; \
+            ln -s Microsoft.AspNetCore.App.Runtime.rhel.9-${ARCH} Microsoft.AspNetCore.App.Runtime.linux-${ARCH}; \
             ln -s Microsoft.AspNetCore.App.Ref Microsoft.AspNetCore.App.linux-${ARCH}; \
             ln -s Microsoft.NETCore.App.Host.rhel.9-${ARCH} Microsoft.NETCore.App.Host.linux-${ARCH}; \
-            ln -s Microsoft.NETCore.App.Ref Microsoft.NETCore.App.Runtime.linux-${ARCH}; \
+            ln -s Microsoft.NETCore.App.Runtime.rhel.9-${ARCH} Microsoft.NETCore.App.Runtime.linux-${ARCH}; \
         fi
+
+ENV     DOTNET_NUGET_SIGNATURE_VERIFICATION=false
 
 RUN     cd /tmp/runner/src && \
         ./dev.sh layout && \

--- a/build-files/convert-rpm.sh
+++ b/build-files/convert-rpm.sh
@@ -1,41 +1,42 @@
 #!/bin/bash
 . /etc/os-release
 SDK=$1
-ARCH=`uname -m`
-MIRROR="https://mirror.lchs.network/pub/almalinux/9.3/AppStream/${ARCH}/os/Packages"
-case "${SDK}" in
-    7)
-        PKGS="dotnet-apphost-pack-7.0-7.0.15-1.el9_3 dotnet-host-8.0.1-1.el9_3"
-        PKGS="${PKGS} dotnet-hostfxr-7.0-7.0.15-1.el9_3 dotnet-targeting-pack-7.0-7.0.15-1.el9_3"
-        PKGS="${PKGS} dotnet-templates-7.0-7.0.115-1.el9_3 dotnet-runtime-7.0-7.0.15-1.el9_3"
-        PKGS="${PKGS} dotnet-sdk-7.0-7.0.115-1.el9_3 aspnetcore-runtime-7.0-7.0.15-1.el9_3"
-        PKGS="${PKGS} aspnetcore-targeting-pack-7.0-7.0.15-1.el9_3 netstandard-targeting-pack-2.1-8.0.101-1.el9_3"
-        ;;
-    6)
-        PKGS="dotnet-host-8.0.1-1.el9_3 dotnet-apphost-pack-6.0-6.0.26-1.el9_3"
-        PKGS="${PKGS} dotnet-hostfxr-6.0-6.0.26-1.el9_3 dotnet-targeting-pack-6.0-6.0.26-1.el9_3"
-        PKGS="${PKGS} dotnet-templates-6.0-6.0.126-1.el9_3 dotnet-runtime-6.0-6.0.26-1.el9_3"
-        PKGS="${PKGS} dotnet-sdk-6.0-6.0.126-1.el9_3 aspnetcore-runtime-6.0-6.0.26-1.el9_3"
-        PKGS="${PKGS} aspnetcore-targeting-pack-6.0-6.0.26-1.el9_3 netstandard-targeting-pack-2.1-8.0.101-1.el9_3"
-        ;;
-    *)
-        echo "Unsupported SDK ${SDK}" >&2
+ARCH=$(uname -m)
+MIRROR=https://mirror.lchs.network/pub/almalinux/9/AppStream/${ARCH}/os/Packages
+PKGS_HTML=$(wget --output-document=- "$MIRROR")
+PKG_NAMES=(
+    "dotnet-apphost-pack-${SDK}"
+    "dotnet-host-8"
+    "dotnet-hostfxr-${SDK}"
+    "dotnet-targeting-pack-${SDK}"
+    "dotnet-templates-${SDK}"
+    "dotnet-runtime-${SDK}"
+    "dotnet-sdk-${SDK}"
+    "aspnetcore-runtime-${SDK}"
+    "aspnetcore-targeting-pack-${SDK}"
+    "netstandard-targeting-pack-2.1-8"
+)
+RPMS=()
+for PKG_NAME in "${PKG_NAMES[@]}"; do
+    if [[ "$PKGS_HTML" =~ \"("$PKG_NAME"[^\"]*.rpm)\" ]]; then
+        RPM=${BASH_REMATCH[1]}
+        echo "Found $RPM"
+        RPMS+=("$RPM")
+    else
+        echo "$PKG_NAME not found" >&2
         exit 1
-        ;;
-esac
-echo "Retrieving dotnet packages"
-pushd /tmp >/dev/null
-for pkg in ${PKGS}
-do
-    RPM="${pkg}.${ARCH}.rpm"
-    wget -q ${MIRROR}/${RPM}
-    if [ ${ID} == "ubuntu" ]; then
-        echo -n "Converting ${RPM}... "
-        alien -d ${RPM} |& grep -v ^warning
-        if [ $? -ne 0 ]; then
-            exit 2
-        fi
-        rm -f ${RPM}
     fi
 done
-exit 0
+echo "Retrieving dotnet packages"
+pushd /tmp >/dev/null || exit 1
+for RPM in "${RPMS[@]}"
+do
+    wget "${MIRROR}/${RPM}" || exit 1
+    if [ "${ID}" == "ubuntu" ]; then
+        echo -n "Converting ${RPM}... "
+        if ! alien -d "${RPM}" |& grep -v -e ^warning -e ^Unpacking; then
+            exit 2
+        fi
+        rm -f "${RPM}"
+    fi
+done

--- a/build-files/runner-s390x.patch
+++ b/build-files/runner-s390x.patch
@@ -1,5 +1,5 @@
 diff --git a/src/Directory.Build.props b/src/Directory.Build.props
-index 9db5fac..f02e235 100644
+index 9db5faca..f02e2357 100644
 --- a/src/Directory.Build.props
 +++ b/src/Directory.Build.props
 @@ -44,6 +44,9 @@
@@ -13,10 +13,10 @@ index 9db5fac..f02e235 100644
    <!-- Set TRACE/DEBUG vars -->
    <PropertyGroup>
 diff --git a/src/Misc/externals.sh b/src/Misc/externals.sh
-index 383221e..1555f67 100755
+index e057ecb2..eb422422 100755
 --- a/src/Misc/externals.sh
 +++ b/src/Misc/externals.sh
-@@ -189,3 +189,8 @@ if [[ "$PACKAGERUNTIME" == "linux-arm" ]]; then
+@@ -190,3 +190,8 @@ if [[ "$PACKAGERUNTIME" == "linux-arm" ]]; then
      acquireExternalTool "$NODE_URL/v${NODE16_VERSION}/node-v${NODE16_VERSION}-linux-armv7l.tar.gz" node16 fix_nested_dir
      acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-armv7l.tar.gz" node20 fix_nested_dir
  fi
@@ -26,7 +26,7 @@ index 383221e..1555f67 100755
 +    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-s390x.tar.gz" node20 fix_nested_dir
 +fi
 diff --git a/src/Misc/layoutroot/config.sh b/src/Misc/layoutroot/config.sh
-index 14cc6ba..9b5b8e6 100755
+index 14cc6bab..9b5b8e6f 100755
 --- a/src/Misc/layoutroot/config.sh
 +++ b/src/Misc/layoutroot/config.sh
 @@ -20,25 +20,29 @@ then
@@ -77,7 +77,7 @@ index 14cc6ba..9b5b8e6 100755
  
      if ! [ -x "$(command -v ldconfig)" ]; then
 diff --git a/src/Runner.Common/Constants.cs b/src/Runner.Common/Constants.cs
-index 177e3c9..9545981 100644
+index d68d5cdf..4c6205cf 100644
 --- a/src/Runner.Common/Constants.cs
 +++ b/src/Runner.Common/Constants.cs
 @@ -58,7 +58,8 @@ namespace GitHub.Runner.Common
@@ -100,7 +100,7 @@ index 177e3c9..9545981 100644
              public static readonly Architecture PlatformArchitecture = Architecture.X64;
  #endif
 diff --git a/src/Runner.Common/Util/VarUtil.cs b/src/Runner.Common/Util/VarUtil.cs
-index 97273a1..2a34430 100644
+index 97273a1a..2a344300 100644
 --- a/src/Runner.Common/Util/VarUtil.cs
 +++ b/src/Runner.Common/Util/VarUtil.cs
 @@ -53,6 +53,8 @@ namespace GitHub.Runner.Common.Util
@@ -113,7 +113,7 @@ index 97273a1..2a34430 100644
                          throw new NotSupportedException(); // Should never reach here.
                  }
 diff --git a/src/Test/L0/ConstantGenerationL0.cs b/src/Test/L0/ConstantGenerationL0.cs
-index 2042485..a9d8b46 100644
+index f3c1b8f9..48127330 100644
 --- a/src/Test/L0/ConstantGenerationL0.cs
 +++ b/src/Test/L0/ConstantGenerationL0.cs
 @@ -20,6 +20,7 @@ namespace GitHub.Runner.Common.Tests
@@ -125,7 +125,7 @@ index 2042485..a9d8b46 100644
                  "osx-arm64"
              };
 diff --git a/src/Test/L0/Listener/SelfUpdaterL0.cs b/src/Test/L0/Listener/SelfUpdaterL0.cs
-index 26ba65e..6791df3 100644
+index 26ba65e7..6791df33 100644
 --- a/src/Test/L0/Listener/SelfUpdaterL0.cs
 +++ b/src/Test/L0/Listener/SelfUpdaterL0.cs
 @@ -1,4 +1,4 @@
@@ -150,7 +150,7 @@ index 26ba65e..6791df3 100644
  }
  #endif
 diff --git a/src/Test/L0/Listener/SelfUpdaterV2L0.cs b/src/Test/L0/Listener/SelfUpdaterV2L0.cs
-index 5115a6b..dd8d198 100644
+index 5115a6bb..dd8d198e 100644
 --- a/src/Test/L0/Listener/SelfUpdaterV2L0.cs
 +++ b/src/Test/L0/Listener/SelfUpdaterV2L0.cs
 @@ -1,4 +1,4 @@
@@ -160,7 +160,7 @@ index 5115a6b..dd8d198 100644
  using System.Collections.Generic;
  using System.IO;
 diff --git a/src/Test/L0/Worker/StepHostL0.cs b/src/Test/L0/Worker/StepHostL0.cs
-index f6b5889..26f8e21 100644
+index f6b58890..26f8e216 100644
 --- a/src/Test/L0/Worker/StepHostL0.cs
 +++ b/src/Test/L0/Worker/StepHostL0.cs
 @@ -31,7 +31,7 @@ namespace GitHub.Runner.Common.Tests.Worker
@@ -173,7 +173,7 @@ index f6b5889..26f8e21 100644
          [Trait("Level", "L0")]
          [Trait("Category", "Worker")]
 diff --git a/src/dev.sh b/src/dev.sh
-index fa637d1..8c66f37 100755
+index 8120ef33..695844c3 100755
 --- a/src/dev.sh
 +++ b/src/dev.sh
 @@ -54,6 +54,7 @@ elif [[ "$CURRENT_PLATFORM" == 'linux' ]]; then
@@ -217,10 +217,10 @@ index fa637d1..8c66f37 100755
  heading "Dotnet SDK Version"
  dotnet --version
 diff --git a/src/dir.proj b/src/dir.proj
-index 056a312..8370922 100644
+index 056a312e..7ec511f1 100644
 --- a/src/dir.proj
 +++ b/src/dir.proj
-@@ -41,8 +41,18 @@
+@@ -41,13 +41,27 @@
      </ItemGroup>
  
      <Target Name="Build" DependsOnTargets="GenerateConstant">
@@ -240,15 +240,25 @@ index 056a312..8370922 100644
 +        <MSBuild Targets="Publish" Projects="@(ProjectFiles)" BuildInParallel="false" StopOnFirstFailure="true" Properties="Configuration=$(BUILDCONFIG);PackageRuntime=$(PackageRuntime);Version=$(RunnerVersion);$(PublishRuntimeIdentifier);PublishDir=$(MSBuildProjectDirectory)/../_layout/bin" />
          <Exec Command="%22$(DesktopMSBuild)%22 Runner.Service/Windows/RunnerService.csproj /p:Configuration=$(BUILDCONFIG) /p:PackageRuntime=$(PackageRuntime) /p:OutputPath=%22$(MSBuildProjectDirectory)/../_layout/bin%22" ConsoleToMSBuild="true" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' == 'win-arm64'" />
      </Target>
-
+ 
+     <Target Name="Test" DependsOnTargets="GenerateConstant">
+-        <Exec Command="dotnet build Test/Test.csproj -c $(BUILDCONFIG) /p:PackageRuntime=$(PackageRuntime)" ConsoleToMSBuild="true" />
++        <PropertyGroup>
++            <BuildTestProperties />
++            <BuildTestProperties Condition="'$(PackageRuntime)' == 'linux-s390x'">/p:SelfContained=false</BuildTestProperties>
++        </PropertyGroup>
++        <Exec Command="dotnet build Test/Test.csproj -c $(BUILDCONFIG) /p:PackageRuntime=$(PackageRuntime) $(BuildTestProperties)" ConsoleToMSBuild="true" />
+         <Exec Command="dotnet test Test/Test.csproj -c $(BUILDCONFIG) --no-build --logger:trx" ConsoleToMSBuild="true" />
+     </Target>
+ 
 diff --git a/src/global.json b/src/global.json
-index b014aea..70e3dcc 100644
+index fd07d882..03e72b75 100644
 --- a/src/global.json
 +++ b/src/global.json
 @@ -1,5 +1,5 @@
  {
    "sdk": {
--    "version": "6.0.419"
-+    "version": "6.0.126"
+-    "version": "8.0.303"
++    "version": "8.0.104"
    }
  }

--- a/build-selfhosted.sh
+++ b/build-selfhosted.sh
@@ -47,7 +47,7 @@ if [ -z "${SDK}" ]; then
             SDK=7
             ;;
         s390x)
-            SDK=6
+            SDK=8
             ;;
     esac
 fi


### PR DESCRIPTION
Hi,

I was asked if gaplib worked on s390x Ubuntu with the latest runner and realized that it's unfortunately quite broken at the moment. This PR summarizes my findings.

Uli gave me a hint on how to resolve the self-contained build issue for testing, so now everything fully works.

---

* convert-rpm.sh uses hardcoded package versions, which can no longer
  be found each time AlmaLinux is updated. Always fetch the current
  versions.

* Fix ShellCheck warnings in this script.

* Don't silence wget output so that the script is debuggable.

* Remove the unnecessary "exit 0" at the end.

* Account for alien errors like the following:

    Unpacking of 'dotnet-host-8.0.4-2.el9_4.s390x.rpm' failed at /usr/share/perl5/Alien/Package/Rpm.pm line 168.

  and add a workaround from [1].

* Rebase runner-s390x.patch.

* Use SDK 8 on s390x, since that's what the latest runner requires.

* Move ARGS a bit lower in the Dockerfile to improve caching.

* Turn off package signature verification. AlmaLinux's .NET may contain
  an outdated trust store. See [2] for details.

* Fix the packs symlinks.

* Pass /p:SelfContained=false to the test runner in order to avoid
  apphost issues in ./dev.sh test.

[1] https://github.com/anup-kodlekere/gaplib/issues/14
[2] https://learn.microsoft.com/en-us/dotnet/core/tools/nuget-signed-package-verification

