### PR TITLE
Improve performance by using uncompressed snapshot and priming system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+distro/
 distro/*.tar.*
 distro/rootfs_almalinux_*
 distro/rootfs.squashfs

--- a/build-files/build-image.sh
+++ b/build-files/build-image.sh
@@ -15,7 +15,8 @@ msg() {
 update_fresh_container() {
     header "Upgrading and installing packages"
     sudo DEBIAN_FRONTEND=noninteractive apt-get -qq update -y >/dev/null
-    sudo DEBIAN_FRONTEND=noninteractive apt-get -qq install dotnet-sdk-8.0 -y >/dev/null
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -qq install dotnet-sdk-8.0 make \
+        gcc g++ autoconf automake m4 libtool -y >/dev/null
 
     if [ $? -ne 0 ]; then
         exit 32


### PR DESCRIPTION
#### Improve performance by using uncompressed snapshot and priming system

* .gitignore
  - Ignore all ./distro

* build-files/build-image.sh
  - Install additional packages (e.g. gcc)

* setup-build-env.sh
  - Create snapshot
  - Publish uncompressed snapshot
  - Prime filesystem by launching newly published image